### PR TITLE
Handle optional dependencies lazily

### DIFF
--- a/src/data/datamodule.py
+++ b/src/data/datamodule.py
@@ -4,9 +4,8 @@ Supports TinyStories and other text datasets.
 """
 
 import random
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
-from datasets import load_dataset
 from torch.utils.data import DataLoader, Dataset
 
 from .tokenizers import (
@@ -16,6 +15,34 @@ from .tokenizers import (
     create_tokenizer,
 )
 
+
+_DATASET_LOADER: Optional[Callable[..., Any]] = None
+
+
+def _resolve_load_dataset() -> Callable[..., Any]:
+    """Dynamically import ``datasets.load_dataset`` when needed."""
+
+    global _DATASET_LOADER
+
+    if _DATASET_LOADER is not None:
+        return _DATASET_LOADER
+
+    try:
+        from datasets import load_dataset as hf_load_dataset
+    except ImportError as exc:  # pragma: no cover - exercised when dependency missing
+        raise ImportError(
+            "TinyStoriesDataModule requires the optional 'datasets' package. "
+            "Install it with `pip install datasets` to enable Hugging Face dataset support."
+        ) from exc
+
+    _DATASET_LOADER = hf_load_dataset
+    return _DATASET_LOADER
+
+
+def load_dataset(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to ``datasets.load_dataset`` with a helpful error if it's unavailable."""
+
+    return _resolve_load_dataset()(*args, **kwargs)
 
 class TextDataset(Dataset):
     """Generic text dataset for language modeling."""
@@ -359,6 +386,15 @@ def get_dataset_stats(dataloader: DataLoader) -> Dict[str, Any]:
         total_samples += batch_size
         total_tokens += batch_size * seq_len
         seq_lengths.extend([seq_len] * batch_size)
+
+    if total_samples == 0:
+        return {
+            "total_samples": 0,
+            "total_tokens": 0,
+            "avg_tokens_per_sample": 0.0,
+            "max_seq_length": 0,
+            "min_seq_length": 0,
+        }
 
     return {
         "total_samples": total_samples,

--- a/src/data/tokenizers.py
+++ b/src/data/tokenizers.py
@@ -8,7 +8,20 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import torch
-from transformers import GPT2TokenizerFast
+
+
+def _resolve_gpt2_tokenizer_fast():
+    """Import :class:`transformers.GPT2TokenizerFast` only when required."""
+
+    try:
+        from transformers import GPT2TokenizerFast  # type: ignore import
+    except ImportError as exc:  # pragma: no cover - exercised when dependency missing
+        raise ImportError(
+            "SubwordTokenizer requires the optional 'transformers' package. "
+            "Install it with `pip install transformers` to enable Hugging Face tokenizers."
+        ) from exc
+
+    return GPT2TokenizerFast
 
 
 class CharacterTokenizer:
@@ -145,7 +158,8 @@ class SubwordTokenizer:
     """Wrapper around HuggingFace tokenizer for subword tokenization."""
 
     def __init__(self, model_name: str = "gpt2"):
-        self.tokenizer = GPT2TokenizerFast.from_pretrained(model_name)
+        tokenizer_cls = _resolve_gpt2_tokenizer_fast()
+        self.tokenizer = tokenizer_cls.from_pretrained(model_name)
 
         # Add pad token if not present
         if self.tokenizer.pad_token is None:


### PR DESCRIPTION
## Summary
- lazy load the Hugging Face `datasets` entry point and make dataset statistics resilient to empty loaders
- resolve `transformers.GPT2TokenizerFast` only when the subword tokenizer is used
- update training utilities to use the module-level datamodule entry points and guard evaluation against empty validation data

## Testing
- pytest -o addopts=''

------
https://chatgpt.com/codex/tasks/task_e_68c967801bb4832ba32045566d189b03