### PR TITLE
Fix dataset initialization and relax pytest addopts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,4 +74,4 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "--cov=src --cov-report=term-missing --cov-report=html"
+addopts = "-ra"

--- a/src/data/datamodule.py
+++ b/src/data/datamodule.py
@@ -15,7 +15,6 @@ from .tokenizers import (
     create_tokenizer,
 )
 
-
 _DATASET_LOADER: Optional[Callable[..., Any]] = None
 
 
@@ -48,12 +47,14 @@ def load_dataset(*args: Any, **kwargs: Any) -> Any:
 class TextDataset(Dataset):
     """Generic text dataset for language modeling."""
 
+    def __init__(
+        self,
         texts: List[str],
         tokenizer: Union[CharacterTokenizer, SubwordTokenizer],
         max_length: int = 256,
         stride: int = 128,
         add_special_tokens: bool = True,
-    ):
+    ) -> None:
         self.texts = texts
         self.tokenizer = tokenizer
         self.max_length = max_length


### PR DESCRIPTION
## Summary
- restore the TextDataset constructor in `data/datamodule.py` so the module imports cleanly and builds its sample cache correctly
- simplify the default pytest options in `pyproject.toml` to avoid requiring the coverage plugin in environments that do not install `pytest-cov`

## Testing
- `pytest -q`
- `black --check src tests`
- `isort --check-only src tests`

------
https://chatgpt.com/codex/tasks/task_e_68cae80d4e14832b837c206ca27d2f99