### PR TITLE
Adjust long strings for lint compliance

### DIFF
--- a/src/data/tokenizers.py
+++ b/src/data/tokenizers.py
@@ -18,7 +18,7 @@ def _resolve_gpt2_tokenizer_fast():
     except ImportError as exc:  # pragma: no cover - exercised when dependency missing
         raise ImportError(
             "SubwordTokenizer requires the optional 'transformers' package. "
-            "Install it with `pip install transformers` to enable Hugging Face tokenizers."
+            "Install it with `pip install transformers` to use Hugging Face tokenizers."
         ) from exc
 
     return GPT2TokenizerFast

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -261,8 +261,8 @@ class TestTinyGPT:
 
     def test_gradient_check_tiny_operation(self, model_config):
         """Gradient check for a small operation (as required by blueprint)."""
-        # Test a simple linear layer instead of the complex transformer operations
-        # which involve dropout, layer norms, and other operations that make gradient checking difficult
+        # Use a simple linear layer instead of the full transformer operations.
+        # Dropout, layer norms, and similar pieces make gradient checks unreliable.
         d_model = model_config["d_model"]
         simple_layer = torch.nn.Linear(d_model, d_model)
 


### PR DESCRIPTION
## Summary
- shorten the fallback ImportError guidance for optional transformers dependency
- reword TinyGPT gradient-check helper comments to stay within the line-length limit

## Testing
- `flake8 src tests` *(fails: flake8 not installed in environment and installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68cb041d77dc832bbd47e75589c98061