### PR TITLE
Fix dataset splits and TinyGPT generation issues

### DIFF
--- a/src/data/datamodule.py
+++ b/src/data/datamodule.py
@@ -143,7 +143,8 @@ class TinyStoriesDataModule:
         # Limit number of samples if specified
         if self.max_samples:
             train_samples = min(self.max_samples, len(dataset["train"]))
-            val_samples = min(self.max_samples // 10, len(dataset["validation"]))
+            val_requested = max(1, self.max_samples // 10) if self.max_samples > 0 else 0
+            val_samples = min(val_requested, len(dataset["validation"]))
 
             dataset["train"] = dataset["train"].select(range(train_samples))
             dataset["validation"] = dataset["validation"].select(range(val_samples))


### PR DESCRIPTION
## Summary
- remove the extra next-token shift in TinyGPT so loss aligns with dataset-provided labels
- make autoregressive generation robust to batched decoding and early EOS handling
- ensure TinyStories validation sampling keeps at least one example for small `max_samples`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb5708e09c832b9be05bb37c72fa28